### PR TITLE
Mark/only posts with images

### DIFF
--- a/Petulia.xcodeproj/project.pbxproj
+++ b/Petulia.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1BC56B042632383A00F9CAA8 /* Petfinder-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1BC56B032632383A00F9CAA8 /* Petfinder-Info.plist */; };
 		5447E4F8262657A3009EAB80 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5447E4F7262657A3009EAB80 /* GoogleService-Info.plist */; };
 		54A46A2326266D00001033AA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A46A2226266D00001033AA /* LoginView.swift */; };
 		54A46A2B262674F1001033AA /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A46A2A262674F1001033AA /* Defaults.swift */; };
@@ -78,12 +77,11 @@
 		79FC94762584D2ED001735C4 /* TileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FC94752584D2ED001735C4 /* TileView.swift */; };
 		79FF944C256A562D00149140 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FF944B256A562D00149140 /* Collection+Extension.swift */; };
 		A6E0CB1F799CD964E1235627 /* Pods_Petulia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84A762D3FCD33220583E434E /* Pods_Petulia.framework */; };
-		FE5433CD263149EC004A8D03 /* Petfinder-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FE5433CC263149EC004A8D03 /* Petfinder-Info.plist */; };
+		FE00785E2638BF6200DD5D9C /* Petfinder-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FE00785D2638BF6200DD5D9C /* Petfinder-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		158BE86E7F99D8C63797420F /* Pods-Petulia.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Petulia.release.xcconfig"; path = "Target Support Files/Pods-Petulia/Pods-Petulia.release.xcconfig"; sourceTree = "<group>"; };
-
 		5447E4F7262657A3009EAB80 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		54A46A2226266D00001033AA /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		54A46A2A262674F1001033AA /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
@@ -155,7 +153,7 @@
 		79FC94752584D2ED001735C4 /* TileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileView.swift; sourceTree = "<group>"; };
 		79FF944B256A562D00149140 /* Collection+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extension.swift"; sourceTree = "<group>"; };
 		84A762D3FCD33220583E434E /* Pods_Petulia.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Petulia.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FE5433CC263149EC004A8D03 /* Petfinder-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Petfinder-Info.plist"; sourceTree = "<group>"; };
+		FE00785D2638BF6200DD5D9C /* Petfinder-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Petfinder-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -413,12 +411,11 @@
 		79AF2DA12578D55700226DEB /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				1BC56B032632383A00F9CAA8 /* Petfinder-Info.plist */,
 				695B34F124D6CA1500A15D26 /* AppDelegate.swift */,
 				695B34F324D6CA1500A15D26 /* SceneDelegate.swift */,
 				695B34FF24D6CA2000A15D26 /* Info.plist */,
 				5447E4F7262657A3009EAB80 /* GoogleService-Info.plist */,
-				FE5433CC263149EC004A8D03 /* Petfinder-Info.plist */,
+				FE00785D2638BF6200DD5D9C /* Petfinder-Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -531,14 +528,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
 				697E7D6C24E9528C0039EBF2 /* confetti.json in Resources */,
 				695B34FE24D6CA2000A15D26 /* LaunchScreen.storyboard in Resources */,
 				697E7D6D24E9528C0039EBF2 /* thanks.json in Resources */,
 				794E2CCA25AAF8CB00234FDA /* paws-preloader.json in Resources */,
 				695B34FB24D6CA2000A15D26 /* Preview Assets.xcassets in Resources */,
 				794E2CCB25AAF8CB00234FDA /* cat-preloader.json in Resources */,
-				FE5433CD263149EC004A8D03 /* Petfinder-Info.plist in Resources */,
+				FE00785E2638BF6200DD5D9C /* Petfinder-Info.plist in Resources */,
 				794E2CD125AAFE4100234FDA /* dots-preloader.json in Resources */,
 				5447E4F8262657A3009EAB80 /* GoogleService-Info.plist in Resources */,
 				695B34F824D6CA2000A15D26 /* Assets.xcassets in Resources */,

--- a/Petulia/Views/Home/HomeView.swift
+++ b/Petulia/Views/Home/HomeView.swift
@@ -15,12 +15,16 @@ struct HomeView: View {
   
   @AppStorage(Keys.savedPostcode) var postcode = ""
   @AppStorage(Keys.isDark) var isDark = false
+  @AppStorage(Keys.showOnlyPostWithImages) var showOnlyPetsWithImages = false
   
   @State private var typing = false
   @State private var showSettingsSheet = false
   @State var showMenu = false
   
-  private var filteredPets: [PetDetailViewModel] {
+  var filteredPets: [PetDetailViewModel] {
+    if showOnlyPetsWithImages {
+      return petDataController.allPets.filter { $0.photos.count > 0 }
+    }
     return petDataController.allPets
   }
 

--- a/Petulia/Views/Settings/SettingsView.swift
+++ b/Petulia/Views/Settings/SettingsView.swift
@@ -16,14 +16,13 @@ struct SettingsView: View {
   @State private var isDirty = false
   
   @AppStorage(Keys.savedPostcode) var postcode = ""
+  @AppStorage(Keys.showOnlyPostWithImages) var showOnlyPetsWithImages = false
   
   @State private var typing = false
   
   @State private var accent = Color.pink
   @State private var showColorPicker = false
-  
-  @State private var showOnlyPetsWithImages = false
-  
+    
   var body: some View {
     ZStack (alignment: .bottom) {
       VStack {
@@ -34,7 +33,6 @@ struct SettingsView: View {
           Form {
             resultSessionView()
             themeSessionView()
-            onlyPostsWithImagesToggleView()
             aboutSessionView()
           }
           if !typing {
@@ -96,6 +94,7 @@ private extension SettingsView {
       .keyboardType(.phonePad)
       .disableAutocorrection(true)
       
+      Toggle("Only pets with pictures", isOn: $showOnlyPetsWithImages)
     }
   }
   
@@ -121,25 +120,6 @@ private extension SettingsView {
     .onChange(of: accent) { color in
       theme.setAccentColor(to: color)
     }
-  }
-  
-  func onlyPostsWithImagesToggleView() -> some View {
-    VStack {
-      Toggle("Only pets with pictures", isOn: $showOnlyPetsWithImages)
-      
-      if showOnlyPetsWithImages {
-        
-        
-        
-        
-        // something here
-        
-        
-        
-        
-      }
-    }
-    .contentShape(Rectangle())
   }
 }
 

--- a/Petulia/Views/Settings/SettingsView.swift
+++ b/Petulia/Views/Settings/SettingsView.swift
@@ -22,6 +22,8 @@ struct SettingsView: View {
   @State private var accent = Color.pink
   @State private var showColorPicker = false
   
+  @State private var showOnlyPetsWithImages = false
+  
   var body: some View {
     ZStack (alignment: .bottom) {
       VStack {
@@ -32,6 +34,7 @@ struct SettingsView: View {
           Form {
             resultSessionView()
             themeSessionView()
+            onlyPostsWithImagesToggleView()
             aboutSessionView()
           }
           if !typing {
@@ -118,6 +121,25 @@ private extension SettingsView {
     .onChange(of: accent) { color in
       theme.setAccentColor(to: color)
     }
+  }
+  
+  func onlyPostsWithImagesToggleView() -> some View {
+    VStack {
+      Toggle("Only pets with pictures", isOn: $showOnlyPetsWithImages)
+      
+      if showOnlyPetsWithImages {
+        
+        
+        
+        
+        // something here
+        
+        
+        
+        
+      }
+    }
+    .contentShape(Rectangle())
   }
 }
 


### PR DESCRIPTION
## Only Posts With Images

Added a boolean value to AppStorage that saves if user wants to see only pets with images.

Fixes #4 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested using my phone

- [x] Test A: Made sure to check to see if dogs with no images appeared on the scrollView. Then toggled showOnlyPetsWithImages.
- [x] Test B: Tried Test A with other animals

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings